### PR TITLE
test: disable language via config file

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,4 @@
+---
+languages:
+  markdown:
+    enabled: false

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@
 - This one is correct
 - This needs a fix
 - This one is correct too
+- testing accounts merge

--- a/markdown-with-issues.md
+++ b/markdown-with-issues.md
@@ -1,0 +1,9 @@
+I am just formatting this markdown in very unrecommended ways, I think...
+
+Alalalalalala
+dsf;ksdl;fksd
+dfkldfdfklf
+
+### 1312
+
+## 1313


### PR DESCRIPTION
- [x] 1st commit to introduce some markdown issues
- [x] 2nd commit to add the file disabling markdown analysis to prove they dissapeared

Before disabling the markdown language from config file
<img width="1477" alt="Screenshot 2024-05-23 at 18 20 01" src="https://github.com/troubleshoot-codacy/markdown-fixes/assets/843135/5e9d865c-2320-4a9d-84f2-f675b3c1e4c6">


After disabling it from config file
<img width="1268" alt="Screenshot 2024-05-23 at 18 46 00" src="https://github.com/troubleshoot-codacy/markdown-fixes/assets/843135/e07357e2-524b-4a44-b9b3-bd80d69b6a27">


